### PR TITLE
kv_server: make the receive message size unlimited

### DIFF
--- a/src/import/kv_server.rs
+++ b/src/import/kv_server.rs
@@ -11,8 +11,6 @@ use tikv_util::thd_name;
 
 use super::{ImportKVService, KVImporter, TiKvConfig};
 
-const MAX_GRPC_MSG_LEN: i32 = 32 * 1024 * 1024;
-
 /// ImportKVServer is a gRPC server that provides service to write key-value
 /// pairs into RocksDB engines for later ingesting into tikv-server.
 pub struct ImportKVServer {
@@ -42,7 +40,7 @@ impl ImportKVServer {
         let channel_args = ChannelBuilder::new(Arc::clone(&env))
             .stream_initial_window_size(cfg.grpc_stream_initial_window_size.0 as i32)
             .max_concurrent_stream(cfg.grpc_concurrent_stream)
-            .max_send_message_len(MAX_GRPC_MSG_LEN)
+            .max_send_message_len(-1)
             .max_receive_message_len(-1)
             .build_args();
 

--- a/src/import/kv_server.rs
+++ b/src/import/kv_server.rs
@@ -43,7 +43,7 @@ impl ImportKVServer {
             .stream_initial_window_size(cfg.grpc_stream_initial_window_size.0 as i32)
             .max_concurrent_stream(cfg.grpc_concurrent_stream)
             .max_send_message_len(MAX_GRPC_MSG_LEN)
-            .max_receive_message_len(MAX_GRPC_MSG_LEN)
+            .max_receive_message_len(-1)
             .build_args();
 
         let grpc_server = ServerBuilder::new(Arc::clone(&env))

--- a/tests/integrations/import/kv_service.rs
+++ b/tests/integrations/import/kv_service.rs
@@ -107,6 +107,16 @@ fn test_kv_service() {
     let resp = retry!(send_write(&client, &head, &batch)).unwrap();
     assert!(!resp.has_error());
 
+    let mut m = Mutation::new();
+    m.op = MutationOp::Put;
+    m.set_key(vec![2]);
+    m.set_value(vec![0; 90_000_000]);
+    let mut huge_batch = WriteBatch::new();
+    huge_batch.set_commit_ts(124);
+    huge_batch.mut_mutations().push(m);
+    let resp = retry!(send_write(&client, &head, &huge_batch)).unwrap();
+    assert!(!resp.has_error());
+
     let resp = retry!(client.close_engine(&close)).unwrap();
     assert!(!resp.has_error());
 


### PR DESCRIPTION
Signed-off-by: kennytm <kennytm@gmail.com>

<!--
Thank you for contributing to TiKV Importer! Please read TiKV Importer's [CONTRIBUTING](https://github.com/tikv/importer/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Remove the 32 MB receive message size limit, since some users have a single KV pair of size over 90 MB.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Unit test

## Does this PR affect TiDB Lightning? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

