### PR TITLE
Cargo.toml: set version to 4.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "tikv-importer"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 dependencies = [
  "clap",
  "cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv-importer"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["The TiKV Authors"]
 description = "Tool to help ingesting large number of KV pairs into TiKV cluster"
 license = "Apache-2.0"


### PR DESCRIPTION


<!--
Thank you for contributing to TiKV Importer! Please read TiKV Importer's [CONTRIBUTING](https://github.com/tikv/importer/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Set version to 4.0.0-beta.1.

There seems to be a bug in the Prost generator regarding nested types in `cdcpb.proto`, preventing TiKV upgrade. We'll defer that to the next beta version.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

N/A

## Does this PR affect TiDB Lightning? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

