### PR TITLE
Cherry-pick TLS support to release-3.0, and set version to v3.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "batch-system"
+version = "0.1.0"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
+dependencies = [
+ "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
+ "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,8 +187,8 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.7"
-source = "git+https://github.com/alexcrichton/bzip2-rs.git#96cc4909a1a180a62ca8e3716785dc6f7a7f9ac0"
+version = "0.1.8+1.0.8"
+source = "git+https://github.com/alexcrichton/bzip2-rs.git#461d66916a5e6848e455c6d4fb9a5f70f4617efd"
 dependencies = [
  "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -300,13 +312,13 @@ dependencies = [
 [[package]]
 name = "codec"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
 ]
 
 [[package]]
@@ -326,7 +338,7 @@ dependencies = [
 [[package]]
 name = "cop_codegen"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -338,13 +350,13 @@ dependencies = [
 [[package]]
 name = "cop_datatype"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "tipb 0.0.1 (git+https://github.com/pingcap/tipb.git)",
 ]
 
@@ -433,15 +445,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.7.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -450,14 +462,6 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -624,6 +628,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "engine"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -661,14 +678,14 @@ dependencies = [
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x)",
+ "rocksdb 0.3.0 (git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1036,7 +1053,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1122,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.0#f403b1fae2dc5d67d65a123b40c5b5e987815dea"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.0#d2cf0af79e71516ae40df1d837bea41d4ebef3e1"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1185,14 +1202,14 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x#e26d5bd6078f0c7196ad56e7f67cef1c09269892"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#7ec1dbd99d906c0098e60ccce41a2adae13fb411"
 dependencies = [
- "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
+ "bzip2-sys 0.1.8+1.0.8 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "libtitan_sys 0.0.1 (git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x)",
+ "libtitan_sys 0.0.1 (git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-sys 1.8.3 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)",
  "snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)",
@@ -1202,9 +1219,9 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x#e26d5bd6078f0c7196ad56e7f67cef1c09269892"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#7ec1dbd99d906c0098e60ccce41a2adae13fb411"
 dependencies = [
- "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
+ "bzip2-sys 0.1.8+1.0.8 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1261,13 +1278,13 @@ dependencies = [
 [[package]]
 name = "log_wrappers"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
 ]
 
 [[package]]
@@ -1282,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "match_template"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1749,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "procinfo"
 version = "0.4.2"
-source = "git+https://github.com/tikv/procinfo-rs#5125fc1a69496b73b26b3c08b6e8afc3c665a56e"
+source = "git+https://github.com/tikv/procinfo-rs#309c751b31e644c318ff7c33cda015d43e39ec52"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1760,12 +1777,12 @@ dependencies = [
 [[package]]
 name = "profiler"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "callgrind 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuprofiler 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "valgrind_request 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2230,11 +2247,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x#e26d5bd6078f0c7196ad56e7f67cef1c09269892"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#7ec1dbd99d906c0098e60ccce41a2adae13fb411"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x)",
 ]
 
 [[package]]
@@ -2691,13 +2708,13 @@ dependencies = [
 [[package]]
 name = "test_util"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2719,25 +2736,26 @@ dependencies = [
 
 [[package]]
 name = "tikv"
-version = "3.0.9"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+version = "3.0.10"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "batch-system 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-tz 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codec 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "cop_codegen 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "cop_datatype 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "codec 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "cop_codegen 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "cop_datatype 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion-papi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "engine 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "engine 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "fail 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "farmhash 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2753,8 +2771,8 @@ dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "log_wrappers 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "match_template 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "log_wrappers 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "match_template 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "more-asserts 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "murmur3 0.4.0 (git+https://github.com/pingcap/murmur3.git)",
  "nix 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2764,7 +2782,7 @@ dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pprof 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "procinfo 0.4.2 (git+https://github.com/tikv/procinfo-rs)",
- "profiler 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "profiler 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2789,11 +2807,11 @@ dependencies = [
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tipb 0.0.1 (git+https://github.com/pingcap/tipb.git)",
- "tipb_helper 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tipb_helper 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2809,18 +2827,19 @@ dependencies = [
 
 [[package]]
 name = "tikv-importer"
-version = "3.0.10"
+version = "3.0.11"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "engine 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "engine 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log_wrappers 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "log_wrappers 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2828,11 +2847,10 @@ dependencies = [
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
- "static_assertions 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "test_util 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "tikv 3.0.9 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "test_util 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "tikv 3.0.10 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "tipb 0.0.1 (git+https://github.com/pingcap/tipb.git)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2841,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "tikv_alloc"
 version = "0.1.0"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2854,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "tikv_util"
 version = "0.1.0"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2884,7 +2902,7 @@ dependencies = [
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
  "slog-term 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2925,10 +2943,10 @@ dependencies = [
 [[package]]
 name = "tipb_helper"
 version = "0.0.1"
-source = "git+https://github.com/tikv/tikv.git?tag=v3.0.9#68b3d36f9f9f8b5eb347465e80ae02c98b135e4e"
+source = "git+https://github.com/tikv/tikv.git?tag=v3.0.10#cad9806bf66f0239ef242a7f8c4af22716345c81"
 dependencies = [
- "codec 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
- "cop_datatype 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)",
+ "codec 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
+ "cop_datatype 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)",
  "tipb 0.0.1 (git+https://github.com/pingcap/tipb.git)",
 ]
 
@@ -3391,10 +3409,11 @@ dependencies = [
 [[package]]
 name = "zstd-sys"
 version = "1.4.15+zstd.1.4.4"
-source = "git+https://github.com/gyscos/zstd-rs.git#c0e8491d460311117bacd0262374f8b973ec8b69"
+source = "git+https://github.com/gyscos/zstd-rs.git#bc874a57298bdb500cdb5aeac5f23878b6480d0b"
 dependencies = [
  "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3412,6 +3431,7 @@ dependencies = [
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum batch-system 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
@@ -3420,7 +3440,7 @@ dependencies = [
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)" = "<none>"
+"checksum bzip2-sys 0.1.8+1.0.8 (git+https://github.com/alexcrichton/bzip2-rs.git)" = "<none>"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum callgrind 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7f788eaf239475a3c1e1acf89951255a46c4b9b46cf3e866fc4d0707b4b9e36"
 "checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
@@ -3434,11 +3454,11 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
-"checksum codec 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum codec 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
-"checksum cop_codegen 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
-"checksum cop_datatype 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum cop_codegen 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
+"checksum cop_datatype 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum cpuprofiler 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33f07976bb6821459632d7a18d97ccca005cb5c552f251f822c7c1781c1d7035"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
@@ -3446,9 +3466,8 @@ dependencies = [
 "checksum criterion-papi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd402c80822a64e66751efaca958ac1047a301c9455dce110c8ef1e9b8ecb931"
 "checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
 "checksum crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1c92ff2d7a202d592f5a412d75cf421495c913817781c1cb383bf12a77e185f"
-"checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+"checksum crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b14492071ca110999a20bf90e3833406d5d66bfd93b4e52ec9539025ff43fe0d"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
-"checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2449aaa4ec7ef96e5fb24db16024b935df718e9ae1cec0a1e68feeca2efca7b8"
@@ -3465,10 +3484,11 @@ dependencies = [
 "checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46c7f14685a20f5dd08e7f754f2ea8cc064d8f4214ae21116c106a2768ba7b9b"
+"checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-"checksum engine 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum engine 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
@@ -3525,16 +3545,16 @@ dependencies = [
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum libpapi_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9c687368f5a574f3aaf97cad438fb572a87aa224051e1cd01ad926b1d592886b"
-"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x)" = "<none>"
-"checksum libtitan_sys 0.0.1 (git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x)" = "<none>"
+"checksum librocksdb_sys 0.1.0 (git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x)" = "<none>"
+"checksum libtitan_sys 0.0.1 (git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x)" = "<none>"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum log_wrappers 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum log_wrappers 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum lz4-sys 1.8.3 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)" = "<none>"
-"checksum match_template 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum match_template 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
@@ -3588,7 +3608,7 @@ dependencies = [
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
 "checksum procinfo 0.4.2 (git+https://github.com/tikv/procinfo-rs)" = "<none>"
-"checksum profiler 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum profiler 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "760293453bee1de0a12987422d7c4885f7ee933e4417bb828ed23f7d05c3c390"
 "checksum prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d2b4a6a1ae793e7eb6773a5301a5a08e8929ea5517b677c93e57ce2d0973c02"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
@@ -3638,7 +3658,7 @@ dependencies = [
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rgb 0.8.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
-"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.x)" = "<none>"
+"checksum rocksdb 0.3.0 (git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x)" = "<none>"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -3698,16 +3718,16 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
-"checksum test_util 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum test_util 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum tikv 3.0.9 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
-"checksum tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
-"checksum tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum tikv 3.0.10 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
+"checksum tikv_alloc 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
+"checksum tikv_util 0.1.0 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tipb 0.0.1 (git+https://github.com/pingcap/tipb.git)" = "<none>"
-"checksum tipb_helper 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.9)" = "<none>"
+"checksum tipb_helper 0.0.1 (git+https://github.com/tikv/tikv.git?tag=v3.0.10)" = "<none>"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv-importer"
-version = "3.0.10"
+version = "3.0.11"
 authors = ["The TiKV Authors"]
 description = "Tool to help ingesting large number of KV pairs into TiKV cluster"
 license = "Apache-2.0"
@@ -22,32 +22,32 @@ path = "tests/integrations/import/mod.rs"
 clap = "2.33"
 crc = "1.8"
 crossbeam = "0.5"
-engine = { version = "0.0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.9" }
+engine = { version = "0.0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.10" }
 futures = "0.1"
 futures-cpupool = "0.1"
 grpcio = "0.4"
 kvproto = { version = "0.0.1", git = "https://github.com/pingcap/kvproto.git", branch = "release-3.0" }
 lazy_static = "1.3"
-log_wrappers = { version = "0.0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.9" }
+log_wrappers = { version = "0.0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.10" }
 prometheus = { version = "0.4", default-features = false, features = ["nightly", "push", "process"] }
 quick-error = "1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 slog = { version = "2.4", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "91904ade" }
-tikv = { version = "3.0.2", git = "https://github.com/tikv/tikv.git", tag = "v3.0.9" }
-tikv_util = { version = "0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.9" }
+tikv = { version = "3.0.10", git = "https://github.com/tikv/tikv.git", tag = "v3.0.10" }
+tikv_util = { version = "0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.10" }
 uuid = { version = "0.6", features = [ "serde", "v4" ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
 toml = "0.4"
 
-# temporarily fix build break on lexical-core 0.4.0
-static_assertions = { version = "=0.3.1" }
+# temporarily fix build break on batch-system 0.1.0
+crossbeam071 = { package = "crossbeam", version = "=0.7.1" }
 
 [dev-dependencies]
 tempdir = "0.3"
 rand = "0.6"
-test_util = { version = "0.0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.9" }
+test_util = { version = "0.0.1", git = "https://github.com/tikv/tikv.git", tag = "v3.0.10" }
 
 [features]
 default = ['tikv/default']

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ audit: pre-audit
 clean:
 	cargo clean
 
+check:
+	cargo check --no-default-features --features "${ENABLE_FEATURES}"
+
 build:
 	cargo build --no-default-features --features "${ENABLE_FEATURES}"
 

--- a/etc/tikv-importer.toml
+++ b/etc/tikv-importer.toml
@@ -39,6 +39,11 @@ compression-per-level = ["lz4", "no", "no", "no", "no", "no", "lz4"]
 [rocksdb.writecf]
 compression-per-level = ["lz4", "no", "no", "no", "no", "no", "lz4"]
 
+[security]
+## The path for TLS certificates. Empty string means disabling secure connections.
+# ca-path = ""
+# cert-path = ""
+# key-path = ""
 
 [import]
 # the directory to store importing kv data.

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -34,7 +34,7 @@ use super::common::*;
 use super::Result;
 use crate::import::stream::SSTFile;
 use engine::rocks::util::security::encrypted_env_from_cipher_file;
-use tikv_util::security::SecurityConfig;
+use tikv_util::security::SecurityManager;
 
 /// Engine wraps rocksdb::DB with customized options to support efficient bulk
 /// write.
@@ -42,7 +42,7 @@ pub struct Engine {
     db: Arc<DB>,
     uuid: Uuid,
     db_cfg: DbConfig,
-    security_cfg: SecurityConfig,
+    security_mgr: Arc<SecurityManager>,
 }
 
 impl Engine {
@@ -50,7 +50,7 @@ impl Engine {
         path: P,
         uuid: Uuid,
         db_cfg: DbConfig,
-        security_cfg: SecurityConfig,
+        security_mgr: Arc<SecurityManager>,
     ) -> Result<Engine> {
         let db = {
             let (db_opts, cf_opts) = tune_dboptions_for_bulk_load(&db_cfg);
@@ -60,7 +60,7 @@ impl Engine {
             db: Arc::new(db),
             uuid,
             db_cfg,
-            security_cfg,
+            security_mgr,
         })
     }
 
@@ -96,7 +96,7 @@ impl Engine {
     }
 
     pub fn new_sst_writer(&self) -> Result<SSTWriter> {
-        SSTWriter::new(&self.db_cfg, &self.security_cfg, self.db.path())
+        SSTWriter::new(&self.db_cfg, &self.security_mgr, self.db.path())
     }
 
     pub fn get_size_properties(&self) -> Result<SizeProperties> {
@@ -221,12 +221,13 @@ pub struct SSTWriter {
 }
 
 impl SSTWriter {
-    pub fn new(db_cfg: &DbConfig, security_cfg: &SecurityConfig, path: &str) -> Result<SSTWriter> {
+    pub fn new(db_cfg: &DbConfig, security_mgr: &SecurityManager, path: &str) -> Result<SSTWriter> {
         let mut env = Arc::new(Env::new_mem());
         let mut base_env = None;
-        if !security_cfg.cipher_file.is_empty() {
+        let cipher_file = security_mgr.cipher_file();
+        if !cipher_file.is_empty() {
             base_env = Some(Arc::clone(&env));
-            env = encrypted_env_from_cipher_file(&security_cfg.cipher_file, Some(env))?;
+            env = encrypted_env_from_cipher_file(&cipher_file, Some(env))?;
         }
         let uuid = Uuid::new_v4().to_string();
         // Placeholder. SstFileWriter don't actually use block cache.
@@ -384,14 +385,17 @@ mod tests {
     use tikv::raftstore::store::RegionSnapshot;
     use tikv::storage::mvcc::MvccReader;
     use tikv::storage::BlockCacheConfig;
-    use tikv_util::file::file_exists;
+    use tikv_util::{
+        file::file_exists,
+        security::{SecurityConfig, SecurityManager},
+    };
 
     fn new_engine() -> (TempDir, Engine) {
         let dir = TempDir::new("test_import_engine").unwrap();
         let uuid = Uuid::new_v4();
         let db_cfg = DbConfig::default();
-        let security_cfg = SecurityConfig::default();
-        let engine = Engine::new(dir.path(), uuid, db_cfg, security_cfg).unwrap();
+        let security_mgr = Arc::default();
+        let engine = Engine::new(dir.path(), uuid, db_cfg, security_mgr).unwrap();
         (dir, engine)
     }
 
@@ -429,16 +433,16 @@ mod tests {
 
     #[test]
     fn test_sst_writer() {
-        test_sst_writer_with(1, &[CF_WRITE], &SecurityConfig::default());
-        test_sst_writer_with(1024, &[CF_DEFAULT, CF_WRITE], &SecurityConfig::default());
+        test_sst_writer_with(1, &[CF_WRITE], &SecurityManager::default());
+        test_sst_writer_with(1024, &[CF_DEFAULT, CF_WRITE], &SecurityManager::default());
 
         let temp_dir = TempDir::new("/tmp/encrypted_env_from_cipher_file").unwrap();
-        let security_cfg = create_security_cfg(&temp_dir);
-        test_sst_writer_with(1, &[CF_WRITE], &security_cfg);
-        test_sst_writer_with(1024, &[CF_DEFAULT, CF_WRITE], &security_cfg);
+        let security_mgr = create_security_mgr(&temp_dir);
+        test_sst_writer_with(1, &[CF_WRITE], &security_mgr);
+        test_sst_writer_with(1024, &[CF_DEFAULT, CF_WRITE], &security_mgr);
     }
 
-    fn create_security_cfg(temp_dir: &TempDir) -> SecurityConfig {
+    fn create_security_mgr(temp_dir: &TempDir) -> SecurityManager {
         let path = temp_dir.path().join("cipher_file");
         let mut cipher_file = File::create(&path).unwrap();
         cipher_file.write_all(b"ACFFDBCC").unwrap();
@@ -446,16 +450,17 @@ mod tests {
         let mut security_cfg = SecurityConfig::default();
         security_cfg.cipher_file = path.to_str().unwrap().to_owned();
         assert_eq!(file_exists(&security_cfg.cipher_file), true);
-        security_cfg
+        SecurityManager::new(&security_cfg).unwrap()
     }
 
-    fn test_sst_writer_with(value_size: usize, cf_names: &[&str], security_cfg: &SecurityConfig) {
+    fn test_sst_writer_with(value_size: usize, cf_names: &[&str], security_mgr: &SecurityManager) {
         let temp_dir = TempDir::new("_test_sst_writer").unwrap();
 
         let cfg = DbConfig::default();
         let mut db_opts = cfg.build_opt();
-        if !security_cfg.cipher_file.is_empty() {
-            let env = encrypted_env_from_cipher_file(&security_cfg.cipher_file, None).unwrap();
+        let cipher_file = security_mgr.cipher_file();
+        if !cipher_file.is_empty() {
+            let env = encrypted_env_from_cipher_file(&cipher_file, None).unwrap();
             db_opts.set_env(env);
         }
         let cache = BlockCacheConfig::default().build_shared_cache();
@@ -465,7 +470,7 @@ mod tests {
 
         let n = 10;
         let commit_ts = 10;
-        let mut w = SSTWriter::new(&cfg, &security_cfg, temp_dir.path().to_str().unwrap()).unwrap();
+        let mut w = SSTWriter::new(&cfg, &security_mgr, temp_dir.path().to_str().unwrap()).unwrap();
 
         // Write some keys.
         let value = vec![1u8; value_size];

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -107,6 +107,9 @@ quick_error! {
         ResourceTemporarilyUnavailable(msg: String) {
             display("{}", msg)
         }
+        Security(msg: String) {
+            display("{}", msg)
+        }
     }
 }
 

--- a/src/import/kv_server.rs
+++ b/src/import/kv_server.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use grpcio::{ChannelBuilder, EnvBuilder, Server as GrpcServer, ServerBuilder};
 use kvproto::import_kvpb_grpc::create_import_kv;
 
-use tikv_util::thd_name;
+use tikv_util::{security::SecurityManager, thd_name};
 
 use super::{ImportKVService, KVImporter, TiKvConfig};
 
@@ -22,10 +22,12 @@ impl ImportKVServer {
         let cfg = &tikv.server;
         let addr = SocketAddr::from_str(&cfg.addr).unwrap();
 
+        let security_mgr = Arc::new(SecurityManager::new(&tikv.security).unwrap());
+
         let importer = KVImporter::new(
             tikv.import.clone(),
             tikv.rocksdb.clone(),
-            tikv.security.clone(),
+            security_mgr.clone(),
         )
         .unwrap();
         let import_service = ImportKVService::new(tikv.import.clone(), Arc::new(importer));
@@ -44,8 +46,12 @@ impl ImportKVServer {
             .max_receive_message_len(-1)
             .build_args();
 
-        let grpc_server = ServerBuilder::new(Arc::clone(&env))
-            .bind(format!("{}", addr.ip()), addr.port())
+        let grpc_server = security_mgr
+            .bind(
+                ServerBuilder::new(env.clone()),
+                &addr.ip().to_string(),
+                addr.port(),
+            )
             .channel_args(channel_args)
             .register_service(create_import_kv(import_service))
             .build()

--- a/src/import/kv_service.rs
+++ b/src/import/kv_service.rs
@@ -73,11 +73,12 @@ impl ImportKv for ImportKVService {
         let label = "switch_mode";
         let timer = Instant::now_coarse();
         let min_available_ratio = self.cfg.min_available_ratio;
+        let security_mgr = self.importer.security_mgr.clone();
 
         ctx.spawn(
             self.threads
                 .spawn_fn(move || {
-                    let client = Client::new(req.get_pd_addr(), 1, min_available_ratio)?;
+                    let client = Client::new(req.get_pd_addr(), 1, min_available_ratio, security_mgr)?;
                     match client.switch_cluster(req.get_request()) {
                         Ok(_) => {
                             info!("switch cluster"; "req" => ?req.get_request());
@@ -256,6 +257,7 @@ impl ImportKv for ImportKVService {
         let label = "compact_cluster";
         let timer = Instant::now_coarse();
         let min_available_ratio = self.cfg.min_available_ratio;
+        let security_mgr = self.importer.security_mgr.clone();
 
         let mut compact = req.get_request().clone();
         if compact.has_range() {
@@ -273,7 +275,8 @@ impl ImportKv for ImportKVService {
         ctx.spawn(
             self.threads
                 .spawn_fn(move || {
-                    let client = Client::new(req.get_pd_addr(), 1, min_available_ratio)?;
+                    let client =
+                        Client::new(req.get_pd_addr(), 1, min_available_ratio, security_mgr)?;
                     match client.compact_cluster(&compact) {
                         Ok(_) => {
                             info!("compact cluster"; "req" => ?compact);

--- a/src/import/prepare.rs
+++ b/src/import/prepare.rs
@@ -328,7 +328,6 @@ mod tests {
 
     use tikv::config::DbConfig;
     use tikv::storage::types::Key;
-    use tikv_util::security::SecurityConfig;
 
     fn new_encoded_key(k: &[u8]) -> Vec<u8> {
         if k.is_empty() {
@@ -343,8 +342,8 @@ mod tests {
         let dir = TempDir::new("test_import_prepare_job").unwrap();
         let uuid = Uuid::new_v4();
         let db_cfg = DbConfig::default();
-        let security_cfg = SecurityConfig::default();
-        let engine = Arc::new(Engine::new(dir.path(), uuid, db_cfg, security_cfg).unwrap());
+        let security_mgr = Arc::default();
+        let engine = Arc::new(Engine::new(dir.path(), uuid, db_cfg, security_mgr).unwrap());
 
         // Generate entries to prepare.
         let (n, m) = (4, 4);

--- a/src/import/stream.rs
+++ b/src/import/stream.rs
@@ -205,7 +205,6 @@ mod tests {
 
     use tikv::config::DbConfig;
     use tikv::storage::types::Key;
-    use tikv_util::security::SecurityConfig;
 
     fn open_db<P: AsRef<Path>>(path: P) -> Arc<DB> {
         let path = path.as_ref().to_str().unwrap();
@@ -370,8 +369,8 @@ mod tests {
         let dir = TempDir::new("test_import_sst_file_stream").unwrap();
         let uuid = Uuid::new_v4();
         let db_cfg = DbConfig::default();
-        let security_cfg = SecurityConfig::default();
-        let engine = Arc::new(Engine::new(dir.path(), uuid, db_cfg, security_cfg).unwrap());
+        let security_mgr = Arc::default();
+        let engine = Arc::new(Engine::new(dir.path(), uuid, db_cfg, security_mgr).unwrap());
 
         for i in 0..16 {
             let k = Key::from_raw(&[i]).append_ts(0);

--- a/tests/integrations/import/kv_service.rs
+++ b/tests/integrations/import/kv_service.rs
@@ -11,23 +11,31 @@ use grpcio::{ChannelBuilder, Environment, Result, WriteFlags};
 use kvproto::import_kvpb::*;
 use kvproto::import_kvpb_grpc::*;
 
-use test_util::retry;
+use test_util::{new_security_cfg, retry};
 use tikv_importer::import::{ImportKVServer, TiKvConfig};
+use tikv_util::security::SecurityManager;
 
-fn new_kv_server() -> (ImportKVServer, ImportKvClient, TempDir) {
+fn new_kv_server(enable_client_tls: bool) -> (ImportKVServer, ImportKvClient, TempDir) {
     let temp_dir = TempDir::new("test_import_kv_server").unwrap();
 
     let mut cfg = TiKvConfig::default();
     cfg.server.addr = "127.0.0.1:0".to_owned();
     cfg.import.import_dir = temp_dir.path().to_str().unwrap().to_owned();
+    cfg.security = new_security_cfg();
     let server = ImportKVServer::new(&cfg);
 
     let ch = {
         let env = Arc::new(Environment::new(1));
         let addr = server.bind_addrs().first().unwrap();
-        ChannelBuilder::new(env)
-            .keepalive_timeout(Duration::from_secs(60))
-            .connect(&format!("{}:{}", addr.0, addr.1))
+        let addr = format!("{}:{}", addr.0, addr.1);
+        let builder = ChannelBuilder::new(env).keepalive_timeout(Duration::from_secs(60));
+        if enable_client_tls {
+            SecurityManager::new(&cfg.security)
+                .unwrap()
+                .connect(builder, &addr)
+        } else {
+            builder.connect(&addr)
+        }
     };
     let client = ImportKvClient::new(ch);
 
@@ -38,7 +46,7 @@ fn new_kv_server() -> (ImportKVServer, ImportKvClient, TempDir) {
 
 #[test]
 fn test_kv_service() {
-    let (mut server, client, _) = new_kv_server();
+    let (mut server, client, _) = new_kv_server(true);
     server.start();
 
     let uuid = Uuid::new_v4().as_bytes().to_vec();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV Importer! Please read TiKV Importer's [CONTRIBUTING](https://github.com/tikv/importer/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

* Cherry-pick #40 (needed because TiDB Lightning uses the same binary for all 3.0+ channel).
* Set version to 3.0.11 and update TiKV dependencies to 3.0.10.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit test.

## Does this PR affect TiDB Lightning? (mandatory)

TiDB Lightning can use TLS in the 3.0 cluster.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

