### PR TITLE
remove prometheus process feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,18 +1704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 
 [[package]]
-name = "libflate"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
-dependencies = [
- "adler32",
- "crc32fast",
- "rle-decode-fast",
- "take_mut",
-]
-
-[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,20 +2433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e767ab205e4b292ea2c8e9fa454efe7e66e35026432eef34fed7daa763136d09"
-dependencies = [
- "bitflags",
- "byteorder",
- "hex 0.4.2",
- "lazy_static",
- "libc",
- "libflate",
-]
-
-[[package]]
 name = "procinfo"
 version = "0.4.2"
 source = "git+https://github.com/tikv/procinfo-rs?rev=5125fc1a69496b73b26b3c08b6e8afc3c665a56e#5125fc1a69496b73b26b3c08b6e8afc3c665a56e"
@@ -2479,7 +2453,6 @@ dependencies = [
  "fnv",
  "lazy_static",
  "libc",
- "procfs",
  "protobuf",
  "reqwest",
  "spin",
@@ -3007,12 +2980,6 @@ name = "rgb"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rocksdb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ kvproto = { version = "0.0.2", git = "https://github.com/pingcap/kvproto.git", b
 lazy_static = "1.4"
 log_wrappers = { version = "0.0.1", git = "https://github.com/tikv/tikv.git", branch = "release-4.0" }
 pd_client = { git = "https://github.com/tikv/tikv.git", branch = "release-4.0", default-features = false }
-prometheus = { version = "0.8", features = ["nightly", "push", "process"] }
+prometheus = { version = "0.8", features = ["nightly", "push"] }
 quick-error = "1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV Importer! Please read TiKV Importer's [CONTRIBUTING](https://github.com/tikv/importer/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
After this https://github.com/tikv/tikv/pull/7306 merged.
we will get error when start importer.
```
[FATAL] [setup.rs:118] ["failed to start memory monitor: Error: descriptor Desc { fq_name: \"process_virtual_memory_bytes\", help: \"Virtual memory size in bytes.\", const_label_pairs: [], variable_labels: [], id: 1166094170200363441, dim_hash: 18077976125237009095 } already exists with the same fully-qualified name and const label values"]
```
this because when "process" feature enabled, default [processor](https://github.com/tikv/rust-prometheus/blob/master/src/process_collector.rs#L72) will register label as same as `process_virtual_memory_bytes` with an empty namespace. and [monitor_memory]( https://github.com/tikv/tikv/pull/7306/files#diff-1489fd33ea1fb2aa1c8ab49ede84ad07R117) also register `process_virtual_memory_bytes` with empty namespace.
so, we choose either disable "process" feature in importer or give a namespace to monitor_memory


## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:

- Bug fix (change which fixes an issue)


## How has this PR been tested? (mandatory)


## Does this PR affect TiDB Lightning? (mandatory)
N/A

## Refer to a related PR or issue link (optional)

Fix #63
