### PR TITLE
errors: stop defining description(), which has been deprecated

### DIFF
--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -21,22 +21,22 @@ quick_error! {
         Io(err: IoError) {
             from()
             cause(err)
-            description(err.description())
+            display("{}", err)
         }
         Grpc(err: GrpcError) {
             from()
             cause(err)
-            description(err.description())
+            display("{}", err)
         }
         Uuid(err: uuid::BytesError) {
             from()
             cause(err)
-            description(err.description())
+            display("{}", err)
         }
         Codec(err: CodecError) {
             from()
             cause(err)
-            description(err.description())
+            display("{}", err)
         }
         Future(err: Canceled) {
             from()
@@ -48,13 +48,12 @@ quick_error! {
         }
         Engine(err: engine::Error) {
             from()
-            description("Engine error")
             display("Engine {:?}", err)
         }
         ParseIntError(err: ParseIntError) {
             from()
             cause(err)
-            description(err.description())
+            display("{}", err)
         }
         FileExists(path: PathBuf) {
             display("File {:?} exists", path)
@@ -81,7 +80,7 @@ quick_error! {
         PdRPC(err: PdError) {
             from()
             cause(err)
-            description(err.description())
+            display("{}", err)
         }
         TikvRPC(err: errorpb::Error) {
             display("TikvRPC {:?}", err)
@@ -126,3 +125,8 @@ impl From<errorpb::Error> for Error {
 }
 
 pub type Result<T> = result::Result<T, Error>;
+
+#[test]
+fn test_description() {
+    assert_eq!(Error::from(GrpcError::QueueShutdown).to_string(), GrpcError::QueueShutdown.to_string());
+}


### PR DESCRIPTION
## What have you changed? (mandatory)

Removed all `description()` usage in `Error`, which has been deprecated and causing gRPC warnings always saying only "`description() is deprecated; use Display`".

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Manual test to trigger a gRPC error and check the log.

## Does this PR affect TiDB Lightning? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)
